### PR TITLE
link back to docs from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ See examples plugins:
 - /plugins/board-cleaner
 - /plugins/cats-demo
 
+There are descriptions of some of these examples (including GIFs) at
+https://developers.realtimeboard.com/docs/web-plugin-examples
 
 You can use _plugins/plugin-boilerplate_ demo which already includes:
 - TypeScript


### PR DESCRIPTION
I was trying to work out which plugins to look at first, and ended up doing a line count [1] before I realised that I'd seen GIF-based demos of a bunch of the examples.

Here is a patch to add a link back to the docs from README.md.


[1]
```
~/src/web-plugins$ (for dir in plugins/*/ ; do echo -n $dir; cat $(git ls-files $dir) |  wc -l; done) | sort -g -k 2 
plugins/shake-me/      28
plugins/board-cleaner/      35
plugins/stickers-to-shapes/      42
plugins/cats-demo/      86
plugins/looking-glass/      99
plugins/importer/     107
plugins/extra-notes/     138
plugins/rtb_sticker_pack/     183
plugins/layers/     266
plugins/sdk-tests/     396
plugins/tanks0/     439
plugins/the-noun-project/     934
plugins/tanks/    7094
plugins/plugin-boilerplate/   22375
```