### PR TITLE
re-add rtb.helpers interface to ts definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.iml
 target
 node_modules
+package-lock.json

--- a/plugins/plugin-boilerplate/dist/main.js
+++ b/plugins/plugin-boilerplate/dist/main.js
@@ -89,34 +89,34 @@
 /***/ (function(module, exports) {
 
 const icon24 = '<path fill="currentColor" fill-rule="nonzero" d="M20.156 7.762c-1.351-3.746-4.672-5.297-8.838-4.61-3.9.642-7.284 3.15-7.9 5.736-1.14 4.784-.015 7.031 2.627 8.09.61.244 1.28.412 2.002.518.277.041.549.072.844.097.138.012.576.045.659.053.109.01.198.02.291.035 1.609.263 2.664 1.334 3.146 2.715 7.24-2.435 9.4-6.453 7.17-12.634zm-18.684.662C3.18 1.256 18.297-3.284 22.038 7.084c2.806 7.78-.526 13.011-9.998 15.695-.266.076-.78.173-.759-.287.062-1.296-.47-2.626-1.762-2.837-1.009-.165-10.75.124-8.047-11.23zm9.427 4.113a6.853 6.853 0 0 0 1.787.172c.223.348.442.733.79 1.366.53.967.793 1.412 1.206 2a1 1 0 1 0 1.636-1.15c-.358-.51-.593-.908-1.09-1.812-.197-.36-.358-.649-.503-.899 1.16-.573 1.916-1.605 2.005-2.909.189-2.748-2.65-4.308-6.611-3.267-.443.117-.834.44-.886 1.408-.065 1.192-.12 2.028-.25 3.825-.129 1.808-.185 2.653-.25 3.86a1 1 0 0 0 1.997.108c.05-.913.093-1.617.17-2.702zm.144-2.026c.077-1.106.124-1.82.171-2.675 2.398-.483 3.595.257 3.521 1.332-.08 1.174-1.506 1.965-3.692 1.343z"/>';
-rtb.initialize({
-    extensionPoints: {
-        exportMenu: {
-            title: 'Boilerplate export',
-            svgIcon: icon24,
-            positionPriority: 20,
-            onClick: () => {
-                // Remember that 'modal.html' resolves relative to main.js file. So modal.html have to be in the /dist/ folder.
-                rtb.board.openModal('modal.html');
-            }
-        },
-        toolbar: {
-            title: 'Boilerplate toolbar',
-            toolbarSvgIcon: icon24,
-            librarySvgIcon: icon24,
-            onClick: () => {
-                rtb.board.openLibrary('Boilerplate', 'library.html');
-            }
-        },
-        bottomBar: {
-            title: 'Boilerplate bottomBar',
-            svgIcon: icon24,
-            positionPriority: 13,
-            onClick: () => {
-                rtb.board.openLeftSidebar('sidebar.html');
+rtb.onReady(() => {
+    rtb.initialize({
+        extensionPoints: {
+            exportMenu: {
+                title: 'Boilerplate export',
+                svgIcon: icon24,
+                onClick: () => {
+                    // Remember that 'modal.html' resolves relative to main.js file. So modal.html have to be in the /dist/ folder.
+                    rtb.board.ui.openModal('modal.html');
+                }
+            },
+            toolbar: {
+                title: 'Boilerplate toolbar',
+                toolbarSvgIcon: icon24,
+                librarySvgIcon: icon24,
+                onClick: () => {
+                    rtb.board.ui.openLibrary('library.html', { title: 'Boilerplate' });
+                }
+            },
+            bottomBar: {
+                title: 'Boilerplate bottomBar',
+                svgIcon: icon24,
+                onClick: () => {
+                    rtb.board.ui.openLeftSidebar('sidebar.html');
+                }
             }
         }
-    }
+    });
 });
 
 

--- a/plugins/plugin-boilerplate/dist/modal.js
+++ b/plugins/plugin-boilerplate/dist/modal.js
@@ -118,7 +118,7 @@ if(false) {}
 __webpack_require__(2);
 let closeButton = document.querySelector('.close-button');
 closeButton.addEventListener('click', () => {
-    rtb.board.closeCurrentModal();
+    rtb.board.ui.closeModal();
 });
 
 

--- a/plugins/plugin-boilerplate/dist/sidebar.js
+++ b/plugins/plugin-boilerplate/dist/sidebar.js
@@ -115,14 +115,14 @@ class Root extends react__WEBPACK_IMPORTED_MODULE_0__["Component"] {
     }
     getBoardTitle() {
         return __awaiter(this, void 0, void 0, function* () {
-            let boardInfo = yield rtb.board.getInfo();
+            let boardInfo = yield rtb.board.info.get();
             this.setState({ boardTitle: boardInfo.title });
         });
     }
     deleteAllContent() {
         return __awaiter(this, void 0, void 0, function* () {
-            let allObjects = yield rtb.board.getAllObjects();
-            yield rtb.board.deleteById(allObjects.map(object => object.id));
+            let allObjects = yield rtb.board.widgets.get();
+            yield rtb.board.widgets.deleteById(allObjects.map(object => object.id));
             yield rtb.showNotification('Content has been deleted');
         });
     }
@@ -2556,6 +2556,7 @@ var printWarning = function() {};
 if (true) {
   var ReactPropTypesSecret = __webpack_require__(15);
   var loggedTypeFailures = {};
+  var has = Function.call.bind(Object.prototype.hasOwnProperty);
 
   printWarning = function(text) {
     var message = 'Warning: ' + text;
@@ -2585,7 +2586,7 @@ if (true) {
 function checkPropTypes(typeSpecs, values, location, componentName, getStack) {
   if (true) {
     for (var typeSpecName in typeSpecs) {
-      if (typeSpecs.hasOwnProperty(typeSpecName)) {
+      if (has(typeSpecs, typeSpecName)) {
         var error;
         // Prop type validation may throw. In case they do, we don't want to
         // fail the render phase where it didn't fail before. So we log it.
@@ -2613,8 +2614,7 @@ function checkPropTypes(typeSpecs, values, location, componentName, getStack) {
             'You may have forgotten to pass an argument to the type checker ' +
             'creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and ' +
             'shape all require an argument).'
-          )
-
+          );
         }
         if (error instanceof Error && !(error.message in loggedTypeFailures)) {
           // Only monitor this failure once because there tends to be a lot of the
@@ -2629,6 +2629,17 @@ function checkPropTypes(typeSpecs, values, location, componentName, getStack) {
         }
       }
     }
+  }
+}
+
+/**
+ * Resets warning cache when testing.
+ *
+ * @private
+ */
+checkPropTypes.resetWarningCache = function() {
+  if (true) {
+    loggedTypeFailures = {};
   }
 }
 

--- a/rtb.d.ts
+++ b/rtb.d.ts
@@ -16,6 +16,8 @@ declare module SDK {
 		showNotification(text: string)
 
 		showErrorNotification(text: string)
+
+		helpers: Helpers
 	}
 
 	type EventType =
@@ -341,6 +343,16 @@ declare module SDK {
 	}
 
 	////////////////////////////////////////////////////////////////////////
+	// Legacy Helper interface that is still used in a few examples
+	////////////////////////////////////////////////////////////////////////
+
+	interface Helpers {
+		initScrollableContainerWithDraggableImages(container: Element, options: {
+			draggableImageSelector: string
+		}): HTMLElement
+	}
+
+	////////////////////////////////////////////////////////////////////////
 	// Helpers data
 	////////////////////////////////////////////////////////////////////////
 
@@ -457,4 +469,3 @@ declare module SDK {
 	type LineWidthStyle = number
 	type LineStyleStyle = number
 }
-


### PR DESCRIPTION
It was removed in c402bfd6afbe9d4708757e8eee16b5e0d27b9a80 but its removal
breaks the build for plugins/plugin-boilerplate.

I have re-added it to make the build pass, but I'm assuming that it was
removed on purpose, so I have marked it as a legacy interface. Hopefully this will make it easier to remove again once the examples have been updated. 

If it was removed by accident then I will update my comment.

#### Also includes:
* I made the build pass, and that updated the dist directory. I have included this as a separate commit.
* I added package-lock.json to .gitignore. The upstream recommendation for package-lock.json is to commit it into version control, and use `npm ci` for reproducible builds. If you would prefer me to do this, I can.

In other news, what do you guys use for testing and CI internally? It would be good to check `npm run build` on each PR, and each push to master. I'm happy to contribute CI configs and tests, if you tell me which tools you prefer.